### PR TITLE
Add LOCAL_DOCS_PATH support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ GITHUB_REPO_OWNER=your-github-username
 GITHUB_REPO_NAME=your-repo-name
 GITHUB_DOCS_PATH=docs
 
+# Optional: Override local docs path
+LOCAL_DOCS_PATH=docs
+
 # Optional: For private repositories
 GITHUB_TOKEN=ghp_your_token_here
 

--- a/netlify/functions/lib/docs.js
+++ b/netlify/functions/lib/docs.js
@@ -9,8 +9,11 @@ const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const github_1 = require("./github");
 class LocalDocsAPI {
-    constructor(docsPath = 'docs') {
+    constructor(docsPath = process.env.LOCAL_DOCS_PATH || 'docs') {
         this.docsPath = path_1.default.resolve(docsPath);
+    }
+    getDocsPath() {
+        return this.docsPath;
     }
     async validateDocsFolder() {
         try {
@@ -96,7 +99,8 @@ class LocalDocsAPI {
 }
 class DocsProvider {
     constructor() {
-        this.localAPI = new LocalDocsAPI();
+        const localDocsPath = process.env.LOCAL_DOCS_PATH;
+        this.localAPI = new LocalDocsAPI(localDocsPath);
         this.githubAPI = (0, github_1.createGitHubClient)();
         this.config = { source: 'local', hasLocal: false, hasGitHub: false };
     }
@@ -132,14 +136,15 @@ class DocsProvider {
         // Determine configuration based on what's available
         const hasLocal = localValidation.valid;
         const hasGitHub = githubValidation.valid;
+        const docsPath = this.localAPI.getDocsPath();
         if (hasLocal && hasGitHub) {
             console.log('✅ Both local docs and GitHub are available. Using hybrid mode with local priority.');
-            this.config = { source: 'hybrid', path: 'docs', hasLocal: true, hasGitHub: true };
+            this.config = { source: 'hybrid', path: docsPath, hasLocal: true, hasGitHub: true };
         }
         else if (hasLocal) {
             console.log('✅ Local docs folder found and validated. Using local source.');
             console.log(`ℹ️ GitHub unavailable: ${githubValidation.error}`);
-            this.config = { source: 'local', path: 'docs', hasLocal: true, hasGitHub: false };
+            this.config = { source: 'local', path: docsPath, hasLocal: true, hasGitHub: false };
         }
         else if (hasGitHub) {
             console.log('✅ GitHub repository validated successfully. Using GitHub source.');


### PR DESCRIPTION
## Summary
- support a configurable local docs path
- document LOCAL_DOCS_PATH in `.env.example`

## Testing
- `tsc -p tsconfig.functions.json` *(fails: Cannot find module types)*

------
https://chatgpt.com/codex/tasks/task_e_6865c52b4a208320aa3c76829cae80e1